### PR TITLE
Resté dos a las posibles conexiones

### DIFF
--- a/app.js
+++ b/app.js
@@ -231,7 +231,7 @@ function CortarIP(IPList, maskList){
         broadcastAgrupada[w]=parseInt(broadcastAgrupada[w],2)
     }
     broadcastAMostrar=broadcastAgrupada.join(".")
-    var maxUsr = 2**(32-contMascara)
+    var maxUsr = (2**(32-contMascara))-2
 
     document.getElementById('mensajeMaxUsers').innerHTML = "Max Users: " + maxUsr;
     document.getElementById('mensajeIP').innerHTML = "IP REAL: " + red(IPList, maskList)+"/"+contMascara;


### PR DESCRIPTION
Según la teoría hay que reservar dos conexiones IP de las posibles, la mínima y la máxima, por lo que en realidad son dos menos los posibles usuarios que se pueden conectar a la red